### PR TITLE
include eunit headers only when necessary

### DIFF
--- a/src/js_mochijson2.erl
+++ b/src/js_mochijson2.erl
@@ -510,8 +510,8 @@ tokenize(B, S=#decoder{offset=O}) ->
 %%
 %% Tests
 %%
--include_lib("eunit/include/eunit.hrl").
 -ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
 
 
 %% testing constructs borrowed from the Yaws JSON implementation.


### PR DESCRIPTION
include eunit only within the ifdef(TEST) blocks. This avoids an eunit dependency during non-test compilation.
