### PR TITLE
Bz1007 inconsistent map phase behavior

### DIFF
--- a/c_src/spidermonkey_drv.c
+++ b/c_src/spidermonkey_drv.c
@@ -115,7 +115,10 @@ void run_js(void *jsargs) {
     char *filename = read_string(&data);
     char *code = read_string(&data);
     result = sm_eval(dd->vm, filename, code, 1);
-    if (strstr(result, "{\"error\"") != NULL) {
+    if (strstr(result, "\"data\":{\"error\":\"notfound\"") != NULL) {
+      send_error_string_response(dd, call_id, "{\"error\":\"map_reduce_error\"}");
+    }
+    else if (strstr(result, "{\"error\"") != NULL) {
       send_error_string_response(dd, call_id, result);
     }
     else {

--- a/c_src/spidermonkey_drv.c
+++ b/c_src/spidermonkey_drv.c
@@ -115,7 +115,7 @@ void run_js(void *jsargs) {
     char *filename = read_string(&data);
     char *code = read_string(&data);
     result = sm_eval(dd->vm, filename, code, 1);
-    if (strstr(result, "\"data\":{\"error\":\"notfound\"") != NULL) {
+    if (strstr(result, "\"data\":\"{\\\"error\\\":\\\"notfound\\\"") != NULL) {
       send_error_string_response(dd, call_id, "{\"error\":\"map_reduce_error\"}");
     }
     else if (strstr(result, "{\"error\"") != NULL) {

--- a/src/js_driver.erl
+++ b/src/js_driver.erl
@@ -152,7 +152,9 @@ eval_js(Ctx, Js, Timeout) when is_binary(Js) ->
             case js_mochijson2:decode(ErrorJson) of
                 {struct, [{<<"error">>, {struct, Error}}]} ->
                     {error, Error};
-                _ ->
+                {struct, [{<<"error">>, Error}]} ->
+                    {error, Error};
+                _ ->                    
                     {error, ErrorJson}
             end;
         {error, Error} ->


### PR DESCRIPTION
These changes along with the accompanying changes to riak_kv resolve the inconsistent handling of 'notfound' errors between erlang and javascript map functions. These changes adopt option number 2 that was outlined in the [bugzilla ticket](https://issues.basho.com/show_bug.cgi?id=1007): all 'notfound' errors are passed to the map functions and may be handled there. In the case the errors are not handled by the map functions, the error output returned from using erlang and javascript functions in HTTP MapReduce queries are consistent now. 

There is still more work to be done to cleanup and improve MapReduce error handling, but I found it to be out of scope of this ticket.
