### PR TITLE
Bz1041 nested error properties

### DIFF
--- a/c_src/spidermonkey_drv.c
+++ b/c_src/spidermonkey_drv.c
@@ -115,7 +115,7 @@ void run_js(void *jsargs) {
     char *filename = read_string(&data);
     char *code = read_string(&data);
     result = sm_eval(dd->vm, filename, code, 1);
-    if (strstr(result, "{\"error\"") != NULL) {
+    if ((strncmp(result, "[{\"error\":\"notfound\"}]", 22) == 0) || (strncmp(result, "{\"error\"", 8) == 0)) {
       send_error_string_response(dd, call_id, result);
     }
     else {

--- a/tests/eval_tests.erl
+++ b/tests/eval_tests.erl
@@ -30,7 +30,15 @@ function_test_() ->
                ?assertMatch(ok, js:define(P, <<"function get_first(data) { return data[\"first\"]; };">>)),
                Data = {struct, [{<<"first">>, <<"abc">>}]},
                ?assertMatch({ok, <<"abc">>}, js:call(P, <<"get_first">>, [Data])),
-               erlang:unlink(P) end]}].
+               erlang:unlink(P) end,
+      fun() ->
+              %% Regression test case for embedded error properties in function return values
+              P = test_util:get_thing(),
+              ?assertMatch(ok, js:define(P, <<"function return_error_property() { return [{\"value\": \"some_value\", \"list\": [{\"error\": \"some_error\"}]}]; }">>)),
+              ?assertMatch({ok,[{struct,[{<<"value">>,<<"some_value">>},{<<"list">>,[{struct,[{<<"error">>,<<"some_error">>}]}]}]}]}, js:call(P, <<"return_error_property">>, [])),
+              erlang:unlink(P) end      
+      ]      
+     }].
 
 binding_test_() ->
     [{setup, fun test_util:port_setup/0,


### PR DESCRIPTION
This is to address bz 1041. Instead of scanning the entire return value from the sm_eval function for an error property, an error condition is only triggered if sm_eval returns a string that begins with:
    {"error"
or is a list containing single notfound error tuple as follows:
    [{"error":"notfound"}]

The latter case is probably unnecessary since notfound errors are not currently passed to javascript functions, but there was an existing test case for that condition and to avoid any unintended consequences I elected to maintain the current behavior and keep the test passing.
