### PR TITLE
Fix for memory handling issue exposed by fixes for BZ1015.

### DIFF
--- a/c_src/spidermonkey.c
+++ b/c_src/spidermonkey.c
@@ -77,20 +77,22 @@ void on_error(JSContext *context, const char *message, JSErrorReport *report) {
 }
 
 JSBool on_branch(JSContext *context, JSScript *script) {
+  JSBool return_value = JS_TRUE;
   spidermonkey_state *state = (spidermonkey_state *) JS_GetContextPrivate(context);
   state->branch_count++;
-  if (state->branch_count == 550) {
+
+  if (state->terminate)  {
+      return_value = JS_FALSE;
+  }
+  else if (state->branch_count == 550) {
     JS_GC(context);
     state->branch_count = 0;
   }
   else if(state->branch_count % 100 == 0) {
     JS_MaybeGC(context);
   }
-  else if (state->terminate)  {
-      return JS_FALSE;
-  }
 
-  return JS_TRUE;
+  return return_value;
 }
 
 void write_timestamp(FILE *fd) {

--- a/c_src/spidermonkey.h
+++ b/c_src/spidermonkey.h
@@ -27,6 +27,7 @@ typedef struct _spidermonkey_error_t {
 typedef struct _spidermonkey_state_t {
   int branch_count;
   spidermonkey_error *error;
+  int terminate;
 } spidermonkey_state;
 
 typedef struct _spidermonkey_vm_t {


### PR DESCRIPTION
When stopping a Spidermonkey VM context make sure any executing JS functions are terminated before beginning to clean up memory.

This change should allow the changes to luke and riak_kv to address BZ1015 to be safely merged.
