### PR TITLE
Add BSD support to erlang_js

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,30 @@
+
+all:
+	$(REBAR) compile
+
+verbose:
+	$(REBAR) compile verbose=1
+
+clean: c_src_clean
+	rm -rf tests_ebin docs
+	$(REBAR) clean
+
+c_src:
+	cd c_src; $(MAKE)
+
+c_src_clean:
+	cd c_src; $(MAKE) clean
+
+test: all
+	@mkdir -p tests_ebin
+	@cd tests;erl -make
+	@erl -noshell -boot start_sasl -pa ebin -pa tests_ebin -s erlang_js -eval 'test_suite:test().' -s init stop
+	@rm -f ebin/test_* ebin/*_tests.erl
+
+docs: all
+	@mkdir -p docs
+	@./build_docs.sh
+	
+.PHONY: c_src docs
+
+include rebar.mk

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,25 @@
+# This is a stub Makefile that invokes GNU make which will read the GNUmakefile
+# instead of this file. This provides compatability on systems where GNU make is
+# not the system 'make' (eg. most non-linux UNIXes).
 
 all:
-	$(REBAR) compile
+	@gmake all
 
 verbose:
-	$(REBAR) compile verbose=1
+	@gmake verbose
+
+test:
+	@gmake test
+
+docs:
+	@gmake docs
+
+c_src: FORCE
+	@gmake c_src
+FORCE:
+
+c_src_clean:
+	@gmake c_src_clean
 
 clean:
-	rm -rf tests_ebin docs
-	$(REBAR) clean
-	cd c_src; $(MAKE) clean
-
-test: all
-	@mkdir -p tests_ebin
-	@cd tests;erl -make
-	@erl -noshell -boot start_sasl -pa ebin -pa tests_ebin -s erlang_js -eval 'test_suite:test().' -s init stop
-	@rm -f ebin/test_* ebin/*_tests.erl
-
-docs: all
-	@mkdir -p docs
-	@./build_docs.sh
-
-include rebar.mk
-
-
+	@gmake clean

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,10 +1,17 @@
 # This Makefile builds the dependencies (libjs and libnspr) needed by
 # spidermonkey_drv.so
 
+UNAME	:= $(shell uname -s)
 TAR		?= tar
 GUNZIP		?= gunzip
 SMONKEY_VER	:= 1.8.0-rc1
 NSPR_VER	:= 4.8
+
+ifeq ($(UNAME),SunOS)
+	PATCH	?= gpatch
+else
+	PATCH	?= patch
+endif
 
 SYSTEM_DIR := $(CURDIR)/system
 LIB_DIR    := $(SYSTEM_DIR)/lib
@@ -20,7 +27,7 @@ js: $(LIB_DIR)/libjs.a
 $(LIB_DIR)/libjs.a: $(LIB_DIR)/libnspr4.a
 	$(GUNZIP) -c js-$(SMONKEY_VER).tar.gz | $(TAR) xf -
 	@for I in patches/js-*.patch; do \
-		(patch -p1 < $${I} || echo "Skipping patch"); \
+		($(PATCH) -p1 < $${I} || echo "Skipping patch"); \
 	done
 	@$(MAKE) -C $(JS_DIR)/src BUILD_OPT=1 JS_DIST=$(SYSTEM_DIR) \
 		JS_THREADSAFE=1 \
@@ -35,6 +42,9 @@ $(LIB_DIR)/libjs.a: $(LIB_DIR)/libnspr4.a
 
 $(LIB_DIR)/libnspr4.a:
 	$(GUNZIP) -c nsprpub-$(NSPR_VER).tar.gz | $(TAR) xf -
+	@for I in patches/nspr-*.patch; do \
+		($(PATCH) -p1 < $${I} || echo "Skipping patch"); \
+	done
 	(cd $(NSPR_DIR) && \
 	 ./configure --disable-debug --enable-optimize \
                      --prefix=$(SYSTEM_DIR) $(NSPR_SIXTYFOUR) && \

--- a/c_src/patches/js-src-config-DragonFly.mk.patch
+++ b/c_src/patches/js-src-config-DragonFly.mk.patch
@@ -1,0 +1,97 @@
+--- c_src/js.orig/src/config/Dragonfly.mk	1969-12-31 19:00:00.000000000 -0500
++++ c_src/js/src/config/DragonFly.mk	2011-03-30 20:50:05.000000000 -0400
+@@ -0,0 +1,94 @@
++# -*- Mode: makefile -*-
++#
++# ***** BEGIN LICENSE BLOCK *****
++# Version: MPL 1.1/GPL 2.0/LGPL 2.1
++#
++# The contents of this file are subject to the Mozilla Public License Version
++# 1.1 (the "License"); you may not use this file except in compliance with
++# the License. You may obtain a copy of the License at
++# http://www.mozilla.org/MPL/
++#
++# Software distributed under the License is distributed on an "AS IS" basis,
++# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
++# for the specific language governing rights and limitations under the
++# License.
++#
++# The Original Code is Mozilla Communicator client code, released
++# March 31, 1998.
++#
++# The Initial Developer of the Original Code is
++# Netscape Communications Corporation.
++# Portions created by the Initial Developer are Copyright (C) 1998
++# the Initial Developer. All Rights Reserved.
++#
++# Contributor(s):
++#
++# Alternatively, the contents of this file may be used under the terms of
++# either the GNU General Public License Version 2 or later (the "GPL"), or
++# the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
++# in which case the provisions of the GPL or the LGPL are applicable instead
++# of those above. If you wish to allow use of your version of this file only
++# under the terms of either the GPL or the LGPL, and not to allow others to
++# use your version of this file under the terms of the MPL, indicate your
++# decision by deleting the provisions above and replace them with the notice
++# and other provisions required by the GPL or the LGPL. If you do not delete
++# the provisions above, a recipient may use your version of this file under
++# the terms of any one of the MPL, the GPL or the LGPL.
++#
++# ***** END LICENSE BLOCK *****
++
++#
++# Config for FreeBSD/NetBSD/OpenBSD.
++#
++
++#CC = gcc
++#CCC = g++
++CFLAGS+=	-Wall -Wno-format
++OS_CFLAGS=	-DXP_UNIX -DSVR4 
++OS_CFLAGS+=	-DSYSV -D_BSD_SOURCE -DPOSIX_SOURCE # -DHAVE_LOCALTIME_R
++INTERP_CFLAGS+=	`pkg-config --cflags-only-I nspr`
++
++RANLIB = echo
++MKSHLIB = $(LD) -lm `pkg-config --libs nspr` -shared $(LDFLAGS) $(XMKSHLIBOPTS)
++
++#.c.o:
++#      $(CC) -c -MD $*.d $(CFLAGS) $<
++
++CPU_ARCH = $(shell uname -m)
++# don't filter in x86-64 architecture
++ifneq (amd64,$(CPU_ARCH))
++ifeq (86,$(findstring 86,$(CPU_ARCH)))
++CPU_ARCH = x86
++OS_CFLAGS+= -DX86_LINUX
++
++ifeq (gcc, $(CC))
++# if using gcc on x86, check version for opt bug 
++# (http://bugzilla.mozilla.org/show_bug.cgi?id=24892)
++GCC_VERSION := $(shell gcc -v 2>&1 | grep version | awk '{ print $$3 }')
++GCC_LIST:=$(sort 2.91.66 $(GCC_VERSION) )
++ifeq (2.91.66, $(firstword $(GCC_LIST)))
++CFLAGS+= -DGCC_OPT_BUG
++endif
++endif
++endif
++endif
++
++GFX_ARCH = x
++
++OS_LIBS = -lm $(LDFLAGS)
++
++ASFLAGS += -x assembler-with-cpp
++
++
++ifeq ($(CPU_ARCH),alpha)
++
++# Ask the C compiler on alpha linux to let us work with denormalized
++# double values, which are required by the ECMA spec.
++
++OS_CFLAGS += -mieee
++endif
++
++JS_EDITLINE = 1
++
++OS_CFLAGS += -DHAVE_VA_COPY -DVA_COPY=va_copy
++OS_CFLAGS += -DPIC -fPIC -DJS_HAVE_LONG_LONG -DHAVE_INTTYPES_H

--- a/c_src/patches/js-src-config-FreeBSD.mk.patch
+++ b/c_src/patches/js-src-config-FreeBSD.mk.patch
@@ -1,0 +1,102 @@
+--- c_src.orig/js/src/config/FreeBSD.mk	1969-12-31 19:00:00.000000000 -0500
++++ c_src/js/src/config/FreeBSD.mk	2011-03-30 20:12:51.000000000 -0400
+@@ -0,0 +1,99 @@
++# -*- Mode: makefile -*-
++#
++# ***** BEGIN LICENSE BLOCK *****
++# Version: MPL 1.1/GPL 2.0/LGPL 2.1
++#
++# The contents of this file are subject to the Mozilla Public License Version
++# 1.1 (the "License"); you may not use this file except in compliance with
++# the License. You may obtain a copy of the License at
++# http://www.mozilla.org/MPL/
++#
++# Software distributed under the License is distributed on an "AS IS" basis,
++# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
++# for the specific language governing rights and limitations under the
++# License.
++#
++# The Original Code is Mozilla Communicator client code, released
++# March 31, 1998.
++#
++# The Initial Developer of the Original Code is
++# Netscape Communications Corporation.
++# Portions created by the Initial Developer are Copyright (C) 1998
++# the Initial Developer. All Rights Reserved.
++#
++# Contributor(s):
++#
++# Alternatively, the contents of this file may be used under the terms of
++# either the GNU General Public License Version 2 or later (the "GPL"), or
++# the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
++# in which case the provisions of the GPL or the LGPL are applicable instead
++# of those above. If you wish to allow use of your version of this file only
++# under the terms of either the GPL or the LGPL, and not to allow others to
++# use your version of this file under the terms of the MPL, indicate your
++# decision by deleting the provisions above and replace them with the notice
++# and other provisions required by the GPL or the LGPL. If you do not delete
++# the provisions above, a recipient may use your version of this file under
++# the terms of any one of the MPL, the GPL or the LGPL.
++#
++# ***** END LICENSE BLOCK *****
++
++#
++# Config for all versions of Linux
++#
++
++CC ?= gcc
++CCC ?= g++
++CFLAGS +=  -Wall -Wno-format
++OS_CFLAGS = -DXP_UNIX -DSVR4 -DSYSV -D_BSD_SOURCE -DPOSIX_SOURCE -DHAVE_LOCALTIME_R
++
++RANLIB = echo
++MKSHLIB = $(LD) -shared $(XMKSHLIBOPTS)
++
++#.c.o:
++#      $(CC) -c -MD $*.d $(CFLAGS) $<
++
++CPU_ARCH = $(shell uname -m)
++# don't filter in x86-64 architecture
++ifneq (x86_64,$(CPU_ARCH))
++ifeq (86,$(findstring 86,$(CPU_ARCH)))
++CPU_ARCH = x86
++OS_CFLAGS+= -DX86_LINUX
++
++ifeq (gcc, $(CC))
++# if using gcc on x86, check version for opt bug 
++# (http://bugzilla.mozilla.org/show_bug.cgi?id=24892)
++GCC_VERSION := $(shell gcc -v 2>&1 | grep version | awk '{ print $$3 }')
++GCC_LIST:=$(sort 2.91.66 $(GCC_VERSION) )
++
++ifeq (2.91.66, $(firstword $(GCC_LIST)))
++CFLAGS+= -DGCC_OPT_BUG
++endif
++endif
++endif
++endif
++
++GFX_ARCH = x
++
++OS_LIBS = -lm
++
++ASFLAGS += -x assembler-with-cpp
++
++
++ifeq ($(CPU_ARCH),alpha)
++
++# Ask the C compiler on alpha linux to let us work with denormalized
++# double values, which are required by the ECMA spec.
++
++OS_CFLAGS += -mieee
++endif
++
++# Use the editline library to provide line-editing support.
++JS_READLINE = 1
++
++OS_CFLAGS += -DHAVE_VA_COPY -DVA_COPY=va_copy
++
++ifeq ($(CPU_ARCH),sparc64)
++OS_CFLAGS += -DPIC -fPIC
++else
++OS_CFLAGS += -DPIC -fpic
++endif

--- a/c_src/patches/js-src-config-NetBSD.mk.patch
+++ b/c_src/patches/js-src-config-NetBSD.mk.patch
@@ -1,0 +1,103 @@
+--- c_src/js.old/src/config/NetBSD.mk	Fri Apr  1 20:06:04 2011
++++ c_src/js/src/config/NetBSD.mk	Fri Apr  1 20:31:19 2011
+@@ -0,0 +1,100 @@
++# -*- Mode: makefile -*-
++#
++# ***** BEGIN LICENSE BLOCK *****
++# Version: MPL 1.1/GPL 2.0/LGPL 2.1
++#
++# The contents of this file are subject to the Mozilla Public License Version
++# 1.1 (the "License"); you may not use this file except in compliance with
++# the License. You may obtain a copy of the License at
++# http://www.mozilla.org/MPL/
++#
++# Software distributed under the License is distributed on an "AS IS" basis,
++# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
++# for the specific language governing rights and limitations under the
++# License.
++#
++# The Original Code is Mozilla Communicator client code, released
++# March 31, 1998.
++#
++# The Initial Developer of the Original Code is
++# Netscape Communications Corporation.
++# Portions created by the Initial Developer are Copyright (C) 1998
++# the Initial Developer. All Rights Reserved.
++#
++# Contributor(s):
++#
++# Alternatively, the contents of this file may be used under the terms of
++# either the GNU General Public License Version 2 or later (the "GPL"), or
++# the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
++# in which case the provisions of the GPL or the LGPL are applicable instead
++# of those above. If you wish to allow use of your version of this file only
++# under the terms of either the GPL or the LGPL, and not to allow others to
++# use your version of this file under the terms of the MPL, indicate your
++# decision by deleting the provisions above and replace them with the notice
++# and other provisions required by the GPL or the LGPL. If you do not delete
++# the provisions above, a recipient may use your version of this file under
++# the terms of any one of the MPL, the GPL or the LGPL.
++#
++# ***** END LICENSE BLOCK *****
++
++#
++# Config for all versions of Linux
++#
++
++CC = gcc
++CCC = g++
++CFLAGS +=  -Wall -Wno-format
++OS_CFLAGS = -DXP_UNIX -DSVR4 -DSYSV -D_BSD_SOURCE -DPOSIX_SOURCE -DHAVE_LOCALTIME_R
++
++RANLIB = echo
++MKSHLIB = $(CC) -shared $(XMKSHLIBOPTS)
++
++#.c.o:
++#      $(CC) -c -MD $*.d $(CFLAGS) $<
++
++CPU_ARCH = $(shell uname -m)
++# don't filter in x86-64 architecture
++ifneq (x86_64,$(CPU_ARCH))
++ifeq (86,$(findstring 86,$(CPU_ARCH)))
++CPU_ARCH = x86
++OS_CFLAGS+= -DX86_LINUX
++
++ifeq (gcc, $(CC))
++# if using gcc on x86, check version for opt bug 
++# (http://bugzilla.mozilla.org/show_bug.cgi?id=24892)
++GCC_VERSION := $(shell gcc -v 2>&1 | grep version | awk '{ print $$3 }')
++GCC_LIST:=$(sort 2.91.66 $(GCC_VERSION) )
++
++ifeq (2.91.66, $(firstword $(GCC_LIST)))
++CFLAGS+= -DGCC_OPT_BUG
++endif
++endif
++endif
++endif
++
++GFX_ARCH = x
++
++OS_LIBS = -lm
++
++ASFLAGS += -x assembler-with-cpp
++
++PROG_LIBS += -pthread
++
++ifeq ($(CPU_ARCH),alpha)
++
++# Ask the C compiler on alpha linux to let us work with denormalized
++# double values, which are required by the ECMA spec.
++
++OS_CFLAGS += -mieee
++endif
++
++# Use the editline library to provide line-editing support.
++JS_EDITLINE = 1
++
++OS_CFLAGS += -DHAVE_VA_COPY -DVA_COPY=va_copy
++
++ifeq ($(CPU_ARCH),sparc64)
++OS_CFLAGS += -DPIC -fPIC
++else
++OS_CFLAGS += -DPIC -fpic
++endif

--- a/c_src/patches/js-src-config-OpenBSD.mk.patch
+++ b/c_src/patches/js-src-config-OpenBSD.mk.patch
@@ -1,0 +1,103 @@
+--- c_src/js.old/src/config/OpenBSD.mk	Fri Apr  1 20:06:04 2011
++++ c_src/js/src/config/OpenBSD.mk	Fri Apr  1 20:31:19 2011
+@@ -0,0 +1,100 @@
++# -*- Mode: makefile -*-
++#
++# ***** BEGIN LICENSE BLOCK *****
++# Version: MPL 1.1/GPL 2.0/LGPL 2.1
++#
++# The contents of this file are subject to the Mozilla Public License Version
++# 1.1 (the "License"); you may not use this file except in compliance with
++# the License. You may obtain a copy of the License at
++# http://www.mozilla.org/MPL/
++#
++# Software distributed under the License is distributed on an "AS IS" basis,
++# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
++# for the specific language governing rights and limitations under the
++# License.
++#
++# The Original Code is Mozilla Communicator client code, released
++# March 31, 1998.
++#
++# The Initial Developer of the Original Code is
++# Netscape Communications Corporation.
++# Portions created by the Initial Developer are Copyright (C) 1998
++# the Initial Developer. All Rights Reserved.
++#
++# Contributor(s):
++#
++# Alternatively, the contents of this file may be used under the terms of
++# either the GNU General Public License Version 2 or later (the "GPL"), or
++# the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
++# in which case the provisions of the GPL or the LGPL are applicable instead
++# of those above. If you wish to allow use of your version of this file only
++# under the terms of either the GPL or the LGPL, and not to allow others to
++# use your version of this file under the terms of the MPL, indicate your
++# decision by deleting the provisions above and replace them with the notice
++# and other provisions required by the GPL or the LGPL. If you do not delete
++# the provisions above, a recipient may use your version of this file under
++# the terms of any one of the MPL, the GPL or the LGPL.
++#
++# ***** END LICENSE BLOCK *****
++
++#
++# Config for all versions of Linux
++#
++
++CC = gcc
++CCC = g++
++CFLAGS +=  -Wall -Wno-format
++OS_CFLAGS = -DXP_UNIX -DSVR4 -DSYSV -D_BSD_SOURCE -DPOSIX_SOURCE -DHAVE_LOCALTIME_R
++
++RANLIB = echo
++MKSHLIB = $(CC) -shared $(XMKSHLIBOPTS)
++
++#.c.o:
++#      $(CC) -c -MD $*.d $(CFLAGS) $<
++
++CPU_ARCH = $(shell uname -m)
++# don't filter in x86-64 architecture
++ifneq (x86_64,$(CPU_ARCH))
++ifeq (86,$(findstring 86,$(CPU_ARCH)))
++CPU_ARCH = x86
++OS_CFLAGS+= -DX86_LINUX
++
++ifeq (gcc, $(CC))
++# if using gcc on x86, check version for opt bug 
++# (http://bugzilla.mozilla.org/show_bug.cgi?id=24892)
++GCC_VERSION := $(shell gcc -v 2>&1 | grep version | awk '{ print $$3 }')
++GCC_LIST:=$(sort 2.91.66 $(GCC_VERSION) )
++
++ifeq (2.91.66, $(firstword $(GCC_LIST)))
++CFLAGS+= -DGCC_OPT_BUG
++endif
++endif
++endif
++endif
++
++GFX_ARCH = x
++
++OS_LIBS = -lm
++
++ASFLAGS += -x assembler-with-cpp
++
++PROG_LIBS += -pthread
++
++ifeq ($(CPU_ARCH),alpha)
++
++# Ask the C compiler on alpha linux to let us work with denormalized
++# double values, which are required by the ECMA spec.
++
++OS_CFLAGS += -mieee
++endif
++
++# Use the editline library to provide line-editing support.
++JS_READLINE = 1
++
++OS_CFLAGS += -DHAVE_VA_COPY -DVA_COPY=va_copy
++
++ifeq ($(CPU_ARCH),sparc64)
++OS_CFLAGS += -DPIC -fPIC
++else
++OS_CFLAGS += -DPIC -fpic
++endif

--- a/c_src/patches/js-src-config.mk.patch
+++ b/c_src/patches/js-src-config.mk.patch
@@ -1,6 +1,33 @@
---- c_src.orig/js/src/config.mk	2010-02-10 15:25:09.000000000 -0800
-+++ c_src/js/src/config.mk	2010-02-10 15:26:42.000000000 -0800
-@@ -141,7 +141,9 @@
+--- c_src.orig/js/src/config.mk	2008-03-12 10:36:06.000000000 -0400
++++ c_src/js/src/config.mk	2011-03-30 20:11:30.000000000 -0400
+@@ -100,10 +100,26 @@
+ ifeq ($(OS_ARCH),Darwin)
+ OS_CONFIG      := Darwin
+ else
++ifeq ($(OS_ARCH), NetBSD)
++OS_CONFIG      := NetBSD
++else
++ifeq ($(OS_ARCH), FreeBSD)
++OS_CONFIG      := FreeBSD
++else
++ifeq ($(OS_ARCH), DragonFly)
++OS_CONFIG      := DragonFly
++else
++ifeq ($(OS_ARCH), OpenBSD)
++OS_CONFIG      := OpenBSD
++else
+ OS_CONFIG       := $(OS_ARCH)$(OS_OBJTYPE)$(OS_RELEASE)
+ endif
+ endif
+ endif
++endif
++endif
++endif
++endif
+ 
+ ASFLAGS         =
+ DEFINES         =
+@@ -141,7 +157,9 @@
  
  SO_SUFFIX = so
  

--- a/c_src/patches/nspr-src-Makefile.in.patch
+++ b/c_src/patches/nspr-src-Makefile.in.patch
@@ -1,0 +1,16 @@
+$OpenBSD: patch-mozilla_nsprpub_lib_tests_Makefile_in,v 1.4 2009/08/04 13:56:09 martynas Exp $
+--- mozilla/nsprpub/lib/tests/Makefile.in.orig	Sun Feb 22 20:56:04 2009
++++ mozilla/nsprpub/lib/tests/Makefile.in	Sat Jun 20 23:38:30 2009
+@@ -117,6 +117,12 @@ ifeq (,$(filter-out OpenBSD,$(OS_ARCH)))
+     endif
+ endif
+ 
++ifeq ($(OS_ARCH), OpenBSD)
++        ifeq ($(USE_PTHREADS),1)
++            EXTRA_LIBS = -lpthread
++        endif
++endif
++
+ ifeq ($(OS_ARCH), OSF1)
+ LDOPTS += -rpath $(PWD)/$(dist_libdir) -lpthread
+ endif

--- a/c_src/patches/nspr-src-configure.in.patch
+++ b/c_src/patches/nspr-src-configure.in.patch
@@ -1,0 +1,59 @@
+--- c_src/nsprpub.old/configure.in	2011-03-31 21:51:51 -0400
++++ c_src/nsprpub/configure.in	2011-03-31 21:53:18 -0400
+@@ -1161,6 +1161,29 @@
+     MDCPUCFG_H=_freebsd.cfg
+     PR_MD_CSRCS=freebsd.c
+     ;;
++*-dragonfly*)
++		if test -z "$USE_NSPR_THREADS"; then
++			USE_PTHREADS=1
++		fi
++		AC_DEFINE(XP_UNIX)
++		AC_DEFINE(FREEBSD)
++		AC_DEFINE(HAVE_BSD_FLOCK)
++		AC_DEFINE(HAVE_SOCKLEN_T)
++		CFLAGS="$CFLAGS $(DSO_CFLAGS) -ansi -Wall"    MOZ_OBJFORMAT=`test -x /usr/bin/objformat && /usr/bin/objformat || echo aout`
++		if test "$MOZ_OBJFORMAT" = "elf"; then
++			DLL_SUFFIX=so
++		else
++			DLL_SUFFIX=so.1.0
++		fi
++		MKSHLIB='$(CC) $(DSO_LDOPTS) -o $@'
++		DSO_CFLAGS=-fPIC
++		DSO_LDOPTS='-shared -Wl,-soname -Wl,$(notdir $@)'
++		MDCPUCFG_H=_freebsd.cfg
++		PR_MD_CSRCS=freebsd.c
++		if test "$LIBRUNPATH"; then
++			DSO_LDOPTS="$DSO_LDOPTS -Wl,-R$LIBRUNPATH"
++		fi
++		;;
+ 
+ *-hpux*)
+     AC_DEFINE(XP_UNIX)
+@@ -2511,7 +2534,7 @@
+ 	if test -z "`egrep -i '(unrecognize|unknown)' conftest.out | grep pthread`" && test -z "`egrep -i '(error|incorrect)' conftest.out`" ; then
+ 	    ac_cv_have_dash_pthread=yes
+ 		case "$target_os" in
+-	    freebsd*)
++	    freebsd* | dragonfly*)
+ # Freebsd doesn't use -pthread for compiles, it uses them for linking
+             ;;
+ 	    *)
+@@ -2549,7 +2572,7 @@
+             _PTHREAD_LDFLAGS=
+         fi
+ 	    ;;
+-    *-freebsd*)
++    *-freebsd* | dragonfly*)
+ 	    AC_DEFINE(_REENTRANT)
+ 	    AC_DEFINE(_THREAD_SAFE)
+ 	    dnl -pthread links in -lc_r, so don't specify it explicitly.
+@@ -2630,7 +2653,7 @@
+         AC_DEFINE(_PR_NEED_PTHREAD_INIT)
+     fi
+     ;;
+-*-freebsd*)
++*-freebsd* | dragonfly*)
+     if test -n "$USE_NSPR_THREADS"; then
+         AC_DEFINE(_PR_LOCAL_THREADS_ONLY)
+     fi

--- a/c_src/patches/nspr-src-configure.patch
+++ b/c_src/patches/nspr-src-configure.patch
@@ -1,0 +1,251 @@
+--- c_src/nsprpub.old/configure	2011-03-31 21:51:51 -0400
++++ c_src/nsprpub/configure	2011-03-31 21:54:10 -0400
+@@ -3518,6 +3518,41 @@
+     MDCPUCFG_H=_freebsd.cfg
+     PR_MD_CSRCS=freebsd.c
+     ;;
++*-dragonfly*)
++		if test -z "$USE_NSPR_THREADS"; then
++			USE_PTHREADS=1
++		fi
++		cat >> confdefs.h <<\EOF
++#define XP_UNIX 1
++EOF
++
++		cat >> confdefs.h <<\EOF
++#define FREEBSD 1
++EOF
++
++		cat >> confdefs.h <<\EOF
++#define HAVE_BSD_FLOCK 1
++EOF
++
++		cat >> confdefs.h <<\EOF
++#define HAVE_SOCKLEN_T 1
++EOF
++
++		CFLAGS="$CFLAGS $(DSO_CFLAGS) -ansi -Wall"    MOZ_OBJFORMAT=`test -x /usr/bin/objformat && /usr/bin/objformat || echo aout`
++		if test "$MOZ_OBJFORMAT" = "elf"; then
++			DLL_SUFFIX=so
++		else
++			DLL_SUFFIX=so.1.0
++		fi
++		MKSHLIB='$(CC) $(DSO_LDOPTS) -o $@'
++		DSO_CFLAGS=-fPIC
++		DSO_LDOPTS='-shared -Wl,-soname -Wl,$(notdir $@)'
++		MDCPUCFG_H=_freebsd.cfg
++		PR_MD_CSRCS=freebsd.c
++		if test "$LIBRUNPATH"; then
++			DSO_LDOPTS="$DSO_LDOPTS -Wl,-R$LIBRUNPATH"
++		fi
++		;;
+ 
+ *-hpux*)
+     cat >> confdefs.h <<\EOF
+@@ -4505,17 +4540,17 @@
+         _OPTIMIZE_FLAGS="$_OPTIMIZE_FLAGS -Olimit 4000"
+         ac_safe=`echo "machine/builtins.h" | sed 'y%./+-%__p_%'`
+ echo $ac_n "checking for machine/builtins.h""... $ac_c" 1>&6
+-echo "configure:4509: checking for machine/builtins.h" >&5
++echo "configure:4544: checking for machine/builtins.h" >&5
+ if eval "test \"`echo '$''{'ac_cv_header_$ac_safe'+set}'`\" = set"; then
+   echo $ac_n "(cached) $ac_c" 1>&6
+ else
+   cat > conftest.$ac_ext <<EOF
+-#line 4514 "configure"
++#line 4549 "configure"
+ #include "confdefs.h"
+ #include <machine/builtins.h>
+ EOF
+ ac_try="$ac_cpp conftest.$ac_ext >/dev/null 2>conftest.out"
+-{ (eval echo configure:4519: \"$ac_try\") 1>&5; (eval $ac_try) 2>&5; }
++{ (eval echo configure:4554: \"$ac_try\") 1>&5; (eval $ac_try) 2>&5; }
+ ac_err=`grep -v '^ *+' conftest.out | grep -v "^conftest.${ac_ext}\$"`
+ if test -z "$ac_err"; then
+   rm -rf conftest*
+@@ -5164,7 +5199,7 @@
+     ;;
+ *)
+     echo $ac_n "checking for dlopen in -ldl""... $ac_c" 1>&6
+-echo "configure:5168: checking for dlopen in -ldl" >&5
++echo "configure:5203: checking for dlopen in -ldl" >&5
+ ac_lib_var=`echo dl'_'dlopen | sed 'y%./+-%__p_%'`
+ if eval "test \"`echo '$''{'ac_cv_lib_$ac_lib_var'+set}'`\" = set"; then
+   echo $ac_n "(cached) $ac_c" 1>&6
+@@ -5172,7 +5207,7 @@
+   ac_save_LIBS="$LIBS"
+ LIBS="-ldl  $LIBS"
+ cat > conftest.$ac_ext <<EOF
+-#line 5176 "configure"
++#line 5211 "configure"
+ #include "confdefs.h"
+ /* Override any gcc2 internal prototype to avoid an error.  */
+ /* We use char because int might match the return type of a gcc2
+@@ -5183,7 +5218,7 @@
+ dlopen()
+ ; return 0; }
+ EOF
+-if { (eval echo configure:5187: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext}; then
++if { (eval echo configure:5222: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext}; then
+   rm -rf conftest*
+   eval "ac_cv_lib_$ac_lib_var=yes"
+ else
+@@ -5200,17 +5235,17 @@
+   echo "$ac_t""yes" 1>&6
+   ac_safe=`echo "dlfcn.h" | sed 'y%./+-%__p_%'`
+ echo $ac_n "checking for dlfcn.h""... $ac_c" 1>&6
+-echo "configure:5204: checking for dlfcn.h" >&5
++echo "configure:5239: checking for dlfcn.h" >&5
+ if eval "test \"`echo '$''{'ac_cv_header_$ac_safe'+set}'`\" = set"; then
+   echo $ac_n "(cached) $ac_c" 1>&6
+ else
+   cat > conftest.$ac_ext <<EOF
+-#line 5209 "configure"
++#line 5244 "configure"
+ #include "confdefs.h"
+ #include <dlfcn.h>
+ EOF
+ ac_try="$ac_cpp conftest.$ac_ext >/dev/null 2>conftest.out"
+-{ (eval echo configure:5214: \"$ac_try\") 1>&5; (eval $ac_try) 2>&5; }
++{ (eval echo configure:5249: \"$ac_try\") 1>&5; (eval $ac_try) 2>&5; }
+ ac_err=`grep -v '^ *+' conftest.out | grep -v "^conftest.${ac_ext}\$"`
+ if test -z "$ac_err"; then
+   rm -rf conftest*
+@@ -5243,13 +5278,13 @@
+ 
+ if test $ac_cv_prog_gcc = yes; then
+     echo $ac_n "checking whether ${CC-cc} needs -traditional""... $ac_c" 1>&6
+-echo "configure:5247: checking whether ${CC-cc} needs -traditional" >&5
++echo "configure:5282: checking whether ${CC-cc} needs -traditional" >&5
+ if eval "test \"`echo '$''{'ac_cv_prog_gcc_traditional'+set}'`\" = set"; then
+   echo $ac_n "(cached) $ac_c" 1>&6
+ else
+     ac_pattern="Autoconf.*'x'"
+   cat > conftest.$ac_ext <<EOF
+-#line 5253 "configure"
++#line 5288 "configure"
+ #include "confdefs.h"
+ #include <sgtty.h>
+ Autoconf TIOCGETP
+@@ -5267,7 +5302,7 @@
+ 
+   if test $ac_cv_prog_gcc_traditional = no; then
+     cat > conftest.$ac_ext <<EOF
+-#line 5271 "configure"
++#line 5306 "configure"
+ #include "confdefs.h"
+ #include <termio.h>
+ Autoconf TCGETA
+@@ -5291,12 +5326,12 @@
+ for ac_func in lchown strerror
+ do
+ echo $ac_n "checking for $ac_func""... $ac_c" 1>&6
+-echo "configure:5295: checking for $ac_func" >&5
++echo "configure:5330: checking for $ac_func" >&5
+ if eval "test \"`echo '$''{'ac_cv_func_$ac_func'+set}'`\" = set"; then
+   echo $ac_n "(cached) $ac_c" 1>&6
+ else
+   cat > conftest.$ac_ext <<EOF
+-#line 5300 "configure"
++#line 5335 "configure"
+ #include "confdefs.h"
+ /* System header to define __stub macros and hopefully few prototypes,
+     which can conflict with char $ac_func(); below.  */
+@@ -5319,7 +5354,7 @@
+ 
+ ; return 0; }
+ EOF
+-if { (eval echo configure:5323: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext}; then
++if { (eval echo configure:5358: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext}; then
+   rm -rf conftest*
+   eval "ac_cv_func_$ac_func=yes"
+ else
+@@ -5360,7 +5395,7 @@
+ if test -z "$GNU_CC"; then
+ 
+     echo $ac_n "checking for +Olit support""... $ac_c" 1>&6
+-echo "configure:5364: checking for +Olit support" >&5
++echo "configure:5399: checking for +Olit support" >&5
+ if eval "test \"`echo '$''{'ac_cv_hpux_usable_olit_option'+set}'`\" = set"; then
+   echo $ac_n "(cached) $ac_c" 1>&6
+ else
+@@ -5399,7 +5434,7 @@
+ *)
+     
+ echo $ac_n "checking for pthread_create in -lpthreads""... $ac_c" 1>&6
+-echo "configure:5403: checking for pthread_create in -lpthreads" >&5
++echo "configure:5438: checking for pthread_create in -lpthreads" >&5
+ echo "
+     #include <pthread.h> 
+     void *foo(void *v) { return v; } 
+@@ -5421,7 +5456,7 @@
+         echo "$ac_t""no" 1>&6
+         
+ echo $ac_n "checking for pthread_create in -lpthread""... $ac_c" 1>&6
+-echo "configure:5425: checking for pthread_create in -lpthread" >&5
++echo "configure:5460: checking for pthread_create in -lpthread" >&5
+ echo "
+     #include <pthread.h> 
+     void *foo(void *v) { return v; } 
+@@ -5443,7 +5478,7 @@
+         echo "$ac_t""no" 1>&6
+         
+ echo $ac_n "checking for pthread_create in -lc_r""... $ac_c" 1>&6
+-echo "configure:5447: checking for pthread_create in -lc_r" >&5
++echo "configure:5482: checking for pthread_create in -lc_r" >&5
+ echo "
+     #include <pthread.h> 
+     void *foo(void *v) { return v; } 
+@@ -5465,7 +5500,7 @@
+         echo "$ac_t""no" 1>&6
+         
+ echo $ac_n "checking for pthread_create in -lc""... $ac_c" 1>&6
+-echo "configure:5469: checking for pthread_create in -lc" >&5
++echo "configure:5504: checking for pthread_create in -lc" >&5
+ echo "
+     #include <pthread.h> 
+     void *foo(void *v) { return v; } 
+@@ -5597,14 +5632,14 @@
+       rm -f conftest*
+    ac_cv_have_dash_pthread=no
+    echo $ac_n "checking whether ${CC-cc} accepts -pthread""... $ac_c" 1>&6
+-echo "configure:5601: checking whether ${CC-cc} accepts -pthread" >&5
++echo "configure:5636: checking whether ${CC-cc} accepts -pthread" >&5
+    echo 'int main() { return 0; }' | cat > conftest.c
+    ${CC-cc} -pthread -o conftest conftest.c > conftest.out 2>&1
+    if test $? -eq 0; then
+ 	if test -z "`egrep -i '(unrecognize|unknown)' conftest.out | grep pthread`" && test -z "`egrep -i '(error|incorrect)' conftest.out`" ; then
+ 	    ac_cv_have_dash_pthread=yes
+ 		case "$target_os" in
+-	    freebsd*)
++	    freebsd* | dragonfly*)
+ # Freebsd doesn't use -pthread for compiles, it uses them for linking
+             ;;
+ 	    *)
+@@ -5620,7 +5655,7 @@
+ 			    ac_cv_have_dash_pthreads=no
+     if test "$ac_cv_have_dash_pthread" = "no"; then
+ 	    echo $ac_n "checking whether ${CC-cc} accepts -pthreads""... $ac_c" 1>&6
+-echo "configure:5624: checking whether ${CC-cc} accepts -pthreads" >&5
++echo "configure:5659: checking whether ${CC-cc} accepts -pthreads" >&5
+     	echo 'int main() { return 0; }' | cat > conftest.c
+ 	    ${CC-cc} -pthreads -o conftest conftest.c > conftest.out 2>&1
+     	if test $? -eq 0; then
+@@ -5640,7 +5675,7 @@
+             _PTHREAD_LDFLAGS=
+         fi
+ 	    ;;
+-    *-freebsd*)
++    *-freebsd* | dragonfly*)
+ 	    cat >> confdefs.h <<\EOF
+ #define _REENTRANT 1
+ EOF
+@@ -5754,7 +5789,7 @@
+ 
+     fi
+     ;;
+-*-freebsd*)
++*-freebsd* | dragonfly*)
+     if test -n "$USE_NSPR_THREADS"; then
+         cat >> confdefs.h <<\EOF
+ #define _PR_LOCAL_THREADS_ONLY 1

--- a/c_src/patches/nspr-src-prnetdb.c.patch
+++ b/c_src/patches/nspr-src-prnetdb.c.patch
@@ -1,0 +1,14 @@
+--- c_src/nsprpub.old/pr/src/misc/prnetdb.c	2011-03-31 21:51:51 -0400
++++ c_src/nsprpub/pr/src/misc/prnetdb.c	2011-03-31 21:53:08 -0400
+@@ -114,6 +114,11 @@
+ #define _PR_HAVE_5_ARG_GETPROTO_R
+ #endif
+ 
++#if __DragonFly_version >= 200202
++#define _PR_HAVE_GETPROTO_R
++#define _PR_HAVE_5_ARG_GETPROTO_R
++#endif
++
+ /* BeOS has glibc but not the glibc-style getprotobyxxx_r functions. */
+ #if (defined(__GLIBC__) && __GLIBC__ >= 2 && !defined(XP_BEOS))
+ #define _PR_HAVE_GETPROTO_R

--- a/rebar.config
+++ b/rebar.config
@@ -29,5 +29,5 @@
              {"darwin10.*-32$", "LDFLAGS", "-arch i386"}
             ]}.
 
-{pre_hooks, [{compile, "make -C c_src"}]}.
-{post_hooks, [{clean, "make -C c_src clean"}]}.
+{pre_hooks, [{compile, "make c_src"}]}.
+{post_hooks, [{clean, "make c_src_clean"}]}.


### PR DESCRIPTION
This patch adds .mk files for FreeBSD, NetBSD, OpenBSD and DragonFlyBSD.
It also patches some nspr files so that nspr builds correctly for the
BSDs as well.

The only thing not solved by this commit is the make/gmake issue, which
is also a problem on solaris. On BSD GNU make is called 'gmake' and BSD
make is called 'make'. However rebar is blindly assuming that GNU make
is called 'make', so this is problematic on any non-Linux UNIX flavor.
