### PR TITLE
Move the call to end_request to before the context is destroyed

### DIFF
--- a/c_src/spidermonkey.c
+++ b/c_src/spidermonkey.c
@@ -178,6 +178,8 @@ void sm_stop(spidermonkey_vm *vm) {
       sleep(1);
   }
 
+  end_request(vm);
+
   //Now we should be free to proceed with
   //freeing up memory without worrying about
   //crashing the VM.
@@ -190,7 +192,6 @@ void sm_stop(spidermonkey_vm *vm) {
   JS_SetContextPrivate(vm->context, NULL);
   JS_DestroyContext(vm->context);
   JS_DestroyRuntime(vm->runtime);
-  end_request(vm);
   driver_free(vm);
 }
 


### PR DESCRIPTION
Fixes az://322

The way the code was on sm_stop, the driver's shutdown routine, was
destroying the VM context before calling end_request, which was
operating on the context. This simple change simply calls end_request
before the context is destroyed.
