### PR TITLE
Change erlang_js driver to be compatible with R15 conventions

### DIFF
--- a/c_src/driver_comm.c
+++ b/c_src/driver_comm.c
@@ -21,21 +21,23 @@
 #include <erl_driver.h>
 
 #include "driver_comm.h"
+#include "erl_compatibility.h"
 
 inline int read_int32(char **data) {
   char *d = *data;
   int value = ((((int)(((unsigned char*) (d))[0]))  << 24) |
-	       (((int)(((unsigned char*) (d))[1]))  << 16) |
-	       (((int)(((unsigned char*) (d))[2]))  << 8)  |
-	       (((int)(((unsigned char*) (d))[3]))));
+               (((int)(((unsigned char*) (d))[1]))  << 16) |
+               (((int)(((unsigned char*) (d))[2]))  << 8)  |
+               (((int)(((unsigned char*) (d))[3]))));
   (*data) += 4;
   return value;
 }
 
 char *read_command(char **data) {
-  char *buf = (char *) driver_alloc(COMMAND_SIZE + 1);
-  memset(buf, 0, COMMAND_SIZE + 1);
-  memcpy(buf, (const char *) *data, COMMAND_SIZE);
+  ErlDrvSizeT allocSize = COMMAND_SIZE + 1;
+  char *buf = (char *) driver_alloc(allocSize);
+  memset(buf, 0, (size_t) allocSize);
+  memcpy(buf, (const char *) *data, (size_t) COMMAND_SIZE);
   (*data) += 2;
   return buf;
 }
@@ -44,9 +46,9 @@ char *read_string(char **data) {
   int length = read_int32(data);
   char *buf = NULL;
   if (length > 0) {
-    buf = (char *) driver_alloc(length + 1);
-    memset(buf, 0, length + 1);
-    memcpy(buf, (const char *) *data, length);
+    buf = (char *) driver_alloc((ErlDrvSizeT) length + 1);
+    memset(buf, 0, (size_t)length + 1);
+    memcpy(buf, (const char *) *data, (size_t) length);
     (*data) += length;
   }
   return buf;

--- a/c_src/erl_compatibility.h
+++ b/c_src/erl_compatibility.h
@@ -1,0 +1,33 @@
+/*
+   Copyright (c) 2012 Basho Technologies, Inc.
+
+   This file is provided to you under the Apache License,
+   Version 2.0 (the "License"); you may not use this file
+   except in compliance with the License.  You may obtain
+   a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+
+*/
+
+#ifndef __ERL_COMPATIBILITY_H__
+#define __ERL_COMPATIBILITY_H__
+
+/* For compatibility with OTP releases prior to R15.
+   R15 and greater uses ErlDrvSizeT as an unsigned size
+   like size_t for driver_* calls
+*/
+#if ERL_DRV_EXTENDED_MAJOR_VERSION < 2
+#define ErlDrvSizeT size_t
+#define ErlDrvSSizeT ssize_t
+#endif
+
+
+#endif /* __ERL_COMPATIBILITY_H__ */

--- a/c_src/spidermonkey.c
+++ b/c_src/spidermonkey.c
@@ -102,8 +102,8 @@ void write_timestamp(FILE *fd) {
   t = time(NULL);
   tmp = localtime(&t); /* or gmtime, if you want GMT^H^H^HUTC */
   fprintf(fd, "%02d/%02d/%04d (%02d:%02d:%02d): ",
-	  tmp->tm_mon+1, tmp->tm_mday, tmp->tm_year+1900,
-	  tmp->tm_hour, tmp->tm_min, tmp->tm_sec);
+          tmp->tm_mon+1, tmp->tm_mday, tmp->tm_year+1900,
+          tmp->tm_hour, tmp->tm_min, tmp->tm_sec);
 }
 
 JSBool js_log(JSContext *cx, uintN argc, jsval *vp) {
@@ -131,7 +131,7 @@ JSBool js_log(JSContext *cx, uintN argc, jsval *vp) {
   return JSVAL_TRUE;
 }
 
-void sm_configure_locale() {
+void sm_configure_locale(void) {
   JS_SetCStringsAreUTF8();
 }
 
@@ -160,7 +160,7 @@ spidermonkey_vm *sm_initialize(long thread_stack, long heap_size) {
   JS_SetContextPrivate(vm->context, state);
   JSNative *funptr = (JSNative *) *js_log;
   JS_DefineFunction(vm->context, JS_GetGlobalObject(vm->context), "ejsLog", funptr,
-		    0, JSFUN_FAST_NATIVE);
+                    0, JSFUN_FAST_NATIVE);
   end_request(vm);
 
   return vm;
@@ -171,7 +171,7 @@ void sm_stop(spidermonkey_vm *vm) {
   spidermonkey_state *state = (spidermonkey_state *) JS_GetContextPrivate(vm->context);
   state->terminate = 1;
   JS_SetContextPrivate(vm->context, state);
- 
+
   //Wait for any executing function to stop
   //before beginning to free up any memory.
   while (JS_IsRunning(vm->context))  {
@@ -195,7 +195,7 @@ void sm_stop(spidermonkey_vm *vm) {
   driver_free(vm);
 }
 
-void sm_shutdown() {
+void sm_shutdown(void) {
   JS_ShutDown();
 }
 
@@ -209,20 +209,20 @@ char *escape_quotes(char *text) {
   for (i = 0; i < strlen(text); i++) {
     if (text[i] == '"') {
       if(!escaped) {
-	memcpy(&buf[x], (char *) "\\\"", 2);
-	x += 2;
+        memcpy(&buf[x], (char *) "\\\"", 2);
+        x += 2;
       }
       else {
-	memcpy(&buf[x], &text[i], 1);
-	x++;
+        memcpy(&buf[x], &text[i], 1);
+        x++;
       }
     }
     else {
       if(text[i] =='\\') {
-	escaped = 1;
+        escaped = 1;
       }
       else {
-	escaped = 0;
+        escaped = 0;
       }
       memcpy(&buf[x], &text[i], 1);
       x++;
@@ -242,7 +242,7 @@ char *error_to_json(const spidermonkey_error *error) {
   char *retval = (char *) driver_alloc(size);
 
   snprintf(retval, size, "{\"error\": {\"lineno\": %d, \"message\": \"%s\", \"source\": \"%s\"}}",
-	   error->lineno, error->msg, escaped_source);
+           error->lineno, error->msg, escaped_source);
   driver_free(escaped_source);
   return retval;
 }
@@ -259,32 +259,32 @@ char *sm_eval(spidermonkey_vm *vm, const char *filename, const char *code, int h
   JSScript *script;
   jsval result;
 
-  if (code == NULL) { 
+  if (code == NULL) {
       return NULL;
   }
 
   begin_request(vm);
   script = JS_CompileScript(vm->context,
-			    vm->global,
-			    code, strlen(code),
-			    filename, 1);
+                            vm->global,
+                            code, strlen(code),
+                            filename, 1);
   spidermonkey_state *state = (spidermonkey_state *) JS_GetContextPrivate(vm->context);
   if (state->error == NULL) {
     JS_ClearPendingException(vm->context);
-    JS_ExecuteScript(vm->context, vm->global, script, &result);   
+    JS_ExecuteScript(vm->context, vm->global, script, &result);
     state = (spidermonkey_state *) JS_GetContextPrivate(vm->context);
     if (state->error == NULL) {
       if (handle_retval) {
-	if (JSVAL_IS_STRING(result)) {
-	  JSString *str = JS_ValueToString(vm->context, result);
-	  retval = copy_jsstring(str);
-	}
-	else if(strcmp(JS_GetStringBytes(JS_ValueToString(vm->context, result)), "undefined") == 0) {
-	  retval = copy_string("{\"error\": \"Expression returned undefined\", \"lineno\": 0, \"source\": \"unknown\"}");
-	}
-	else {
-	  retval = copy_string("{\"error\": \"non-JSON return value\", \"lineno\": 0, \"source\": \"unknown\"}");
-	}
+        if (JSVAL_IS_STRING(result)) {
+          JSString *str = JS_ValueToString(vm->context, result);
+          retval = copy_jsstring(str);
+        }
+        else if(strcmp(JS_GetStringBytes(JS_ValueToString(vm->context, result)), "undefined") == 0) {
+          retval = copy_string("{\"error\": \"Expression returned undefined\", \"lineno\": 0, \"source\": \"unknown\"}");
+        }
+        else {
+          retval = copy_string("{\"error\": \"non-JSON return value\", \"lineno\": 0, \"source\": \"unknown\"}");
+        }
       }
       JS_DestroyScript(vm->context, script);
     }

--- a/c_src/spidermonkey.h
+++ b/c_src/spidermonkey.h
@@ -39,13 +39,13 @@ typedef struct _spidermonkey_vm_t {
 /* Bytes to allocate before GC */
 #define MAX_GC_SIZE 1024 * 1024
 
-void sm_configure_locale();
+void sm_configure_locale(void);
 
 spidermonkey_vm *sm_initialize(long thread_stack, long heap_size);
 
 void sm_stop(spidermonkey_vm *vm);
 
-void sm_shutdown();
+void sm_shutdown(void);
 
 char *sm_eval(spidermonkey_vm *vm, const char *filename, const char *code, int handle_retval);
 

--- a/c_src/spidermonkey_drv.c
+++ b/c_src/spidermonkey_drv.c
@@ -44,7 +44,7 @@ typedef void (*asyncfun)(void *);
 
 /* Forward declarations */
 static ErlDrvData start(ErlDrvPort port, char *cmd);
-static int init();
+static int init(void);
 static void stop(ErlDrvData handle);
 static void process(ErlDrvData handle, ErlIOVec *ev);
 static void ready_async(ErlDrvData handle, ErlDrvThreadData async_data);
@@ -75,8 +75,8 @@ static ErlDrvEntry spidermonkey_drv_entry = {
 
 void send_immediate_ok_response(spidermonkey_drv_t *dd, const char *call_id) {
   ErlDrvTermData terms[] = {ERL_DRV_BUF2BINARY, (ErlDrvTermData) call_id, strlen(call_id),
-			    ERL_DRV_ATOM, dd->atom_ok,
-			    ERL_DRV_TUPLE, 2};
+                            ERL_DRV_ATOM, dd->atom_ok,
+                            ERL_DRV_TUPLE, 2};
   driver_output_term(dd->port, terms, sizeof(terms) / sizeof(terms[0]));
 }
 
@@ -93,8 +93,8 @@ void send_ok_response(spidermonkey_drv_t *dd, js_call *call_data,
                       const char *call_id) {
   ErlDrvTermData terms[] = {ERL_DRV_BUF2BINARY,
                             (ErlDrvTermData) call_data->return_call_id,strlen(call_id),
-			    ERL_DRV_ATOM, dd->atom_ok,
-			    ERL_DRV_TUPLE, 2};
+                            ERL_DRV_ATOM, dd->atom_ok,
+                            ERL_DRV_TUPLE, 2};
   COPY_DATA(call_data, call_id, terms);
 }
 
@@ -103,8 +103,8 @@ void send_error_string_response(spidermonkey_drv_t *dd, js_call *call_data,
   ErlDrvTermData terms[] = {ERL_DRV_BUF2BINARY,
                             (ErlDrvTermData) call_data->return_call_id,strlen(call_id),
                             ERL_DRV_ATOM, dd->atom_error,
-			    ERL_DRV_BUF2BINARY, (ErlDrvTermData) msg, strlen(msg),
-			    ERL_DRV_TUPLE, 3};
+                            ERL_DRV_BUF2BINARY, (ErlDrvTermData) msg, strlen(msg),
+                            ERL_DRV_TUPLE, 3};
   COPY_DATA(call_data, call_id, terms);
   call_data->return_string = msg;
 }
@@ -114,8 +114,8 @@ void send_string_response(spidermonkey_drv_t *dd, js_call *call_data,
   ErlDrvTermData terms[] = {ERL_DRV_BUF2BINARY,
                             (ErlDrvTermData) call_data->return_call_id,strlen(call_id),
                             ERL_DRV_ATOM, dd->atom_ok,
-			    ERL_DRV_BUF2BINARY, (ErlDrvTermData) result, strlen(result),
-			    ERL_DRV_TUPLE, 3};
+                            ERL_DRV_BUF2BINARY, (ErlDrvTermData) result, strlen(result),
+                            ERL_DRV_TUPLE, 3};
   COPY_DATA(call_data, call_id, terms);
   call_data->return_string = result;
 }
@@ -125,8 +125,8 @@ void unknown_command(spidermonkey_drv_t *dd, js_call *call_data,
   ErlDrvTermData terms[] = {ERL_DRV_BUF2BINARY,
                             (ErlDrvTermData) call_data->return_call_id,strlen(call_id),
                             ERL_DRV_ATOM, dd->atom_error,
-			    ERL_DRV_ATOM, dd->atom_unknown_cmd,
-			    ERL_DRV_TUPLE, 3};
+                            ERL_DRV_ATOM, dd->atom_unknown_cmd,
+                            ERL_DRV_TUPLE, 3};
   COPY_DATA(call_data, call_id, terms);
 }
 
@@ -179,7 +179,7 @@ DRIVER_INIT(spidermonkey_drv) {
   return &spidermonkey_drv_entry;
 }
 
-static int init() {
+static int init(void) {
   sm_configure_locale();
   return 0;
 }

--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
 {erl_opts, [warnings_as_errors]}.
 
 {port_envs, [
-             {"DRV_CFLAGS", "$DRV_CFLAGS -I c_src/system/include/js -DXP_UNIX -Wstrict-prototypes"},
+             {"DRV_CFLAGS", "$DRV_CFLAGS -I c_src/system/include/js -DXP_UNIX -Wall"},
              {"DRV_LDFLAGS", "$DRV_LDFLAGS c_src/system/lib/libjs.a c_src/system/lib/libnspr4.a"},
 
              %% Define flags for enabling/disable 64 bit build of NSPR

--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
 {erl_opts, [warnings_as_errors]}.
 
 {port_envs, [
-             {"DRV_CFLAGS", "$DRV_CFLAGS -I c_src/system/include/js -DXP_UNIX"},
+             {"DRV_CFLAGS", "$DRV_CFLAGS -I c_src/system/include/js -DXP_UNIX -Wstrict-prototypes"},
              {"DRV_LDFLAGS", "$DRV_LDFLAGS c_src/system/lib/libjs.a c_src/system/lib/libnspr4.a"},
 
              %% Define flags for enabling/disable 64 bit build of NSPR


### PR DESCRIPTION
The erlang driver interface changed to properly support 64-bit architectures. 

The bug OTP-9795 in the [R15B release notes](http://www.erlang.org/download/otp_src_R15B.readme) describes the issue. The instructions on how to rewrite drivers was found [in the erlang manual](http://www.erlang.org/doc/man/erl_driver.html#rewrites_for_64_bits).
