### PR TITLE
Add app_env var for script timeout

### DIFF
--- a/src/js_driver.erl
+++ b/src/js_driver.erl
@@ -138,7 +138,8 @@ define_js(Ctx, FileName, Js, Timeout) when is_binary(FileName),
 %% @spec eval_js(port(), binary()) -> {ok, any()} | {error, any()}
 %% @doc Evaluate a Javascript expression and return the result
 eval_js(Ctx, Js) ->
-    eval_js(Ctx, Js, ?SCRIPT_TIMEOUT).
+    ScriptTimeout = app_helper:get_env(erlang_js, script_timeout, ?SCRIPT_TIMEOUT),
+    eval_js(Ctx, Js, ScriptTimeout).
 
 %% @private
 eval_js(Ctx, {file, FileName}, Timeout) ->


### PR DESCRIPTION
js_driver:eval_js/2 uses a macro SCRIPT_TIMEOUT for the amount of
time to wait for a js script to execute before timing out. In some
instances (testing JS map reduce on limited hardware) it would be
handy to set this timeout higher.

Use the 'erlang_js' app_env var 'script_timeout' and any int value.
Timeout is in milliseconds.
