### PR TITLE
Support non-binary error-reasons in define_js/4

### DIFF
--- a/src/js_driver.erl
+++ b/src/js_driver.erl
@@ -131,6 +131,8 @@ define_js(Ctx, FileName, Js, Timeout) when is_binary(FileName),
         {error, ErrorJson} when is_binary(ErrorJson) ->
             {struct, [{<<"error">>, {struct, Error}}]} = js_mochijson2:decode(ErrorJson),
             {error, Error};
+        {error, Error} ->
+            {error, Error};
         ok ->
             ok
     end.


### PR DESCRIPTION
define_js/4 did not include a pattern to match against non-binary values in
the error tuple that can be a result of evaluating call_driver/4. This caused
case_clause run-time errors when the reason for the error was not a binary.

({error, timeout} for example).
