### PR TITLE
Regardless of OTP rel, build Mountain Lion 64-bit.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -29,8 +29,8 @@
              {"darwin10.*-32$", "LDFLAGS", "-arch i386"},
 
              %% OS X Mountain Lion flags.
-             {"x86_64.*darwin12.4.*$", "CFLAGS", "-m64"},
-             {"x86_64.*darwin12.4.*$", "LDFLAGS", "-arch x86_64"},
+             {".*darwin12.4.*$", "CFLAGS", "-m64"},
+             {".*darwin12.4.*$", "LDFLAGS", "-arch x86_64"},
 
              %% Prevent the make->gmake transition from infecting
              %% MAKEFLAGS with bad flags that confuse gmake


### PR DESCRIPTION
Related to regression produced by #39 on R15 releases. 
