### PR TITLE
Fix R18 erlang:now() deprecation warning

### DIFF
--- a/src/js_benchmark.erl
+++ b/src/js_benchmark.erl
@@ -38,9 +38,9 @@ run() ->
 %% @private
 time_calls(Ctx, Count) ->
     io:format("Starting: ~p~n", [Count]),
-    Start = erlang:now(),
+    Start = os:timestamp(),
     do_calls(Ctx, Count),
-    timer:now_diff(erlang:now(), Start) / Count.
+    timer:now_diff(os:timestamp(), Start) / Count.
 
 %% @private
 do_calls(_Ctx, 0) ->


### PR DESCRIPTION
HI, here is simple fix to remove R18 warning about deprecated erlang:now().
