### PR TITLE
Erlang 18.0 now() fix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,13 @@
 c_src/js
 c_src/system
 c_src/nsprpub
+c_src/driver_comm.d
+c_src/spidermonkey.d
+c_src/spidermonkey_drv.d
+compile
+deps
 docs
 ebin
 .eunit
+.rebar
 tags

--- a/src/erlang_js.app.src
+++ b/src/erlang_js.app.src
@@ -2,7 +2,7 @@
 {application, erlang_js,
  [{description,  "Interface between BEAM and JS"},
   {vsn,          git},
-  {modules,      [erlang_js, erlang_js_sup, js, js_benchmark, js_cache, js_driver, js_drv_comm, js_memory, js_mochijson2, js_mochinum]},
+  {modules,      [erlang_js, erlang_js_sup, erlang_js_time, js, js_benchmark, js_cache, js_driver, js_drv_comm, js_memory, js_mochijson2, js_mochinum]},
   {registered,   [erlang_js_sup, js_cache]},
   {applications, [kernel, stdlib, sasl]},
   {mod, {erlang_js, []}}]}.

--- a/src/erlang_js_time.erl
+++ b/src/erlang_js_time.erl
@@ -1,0 +1,31 @@
+%% @author Bill St. Clair <billstcliar@gmail.com>
+%% @copyright 2015 Basho Technologies
+%%
+%%    Licensed under the Apache License, Version 2.0 (the "License");
+%%    you may not use this file except in compliance with the License.
+%%    You may obtain a copy of the License at
+%%
+%%        http://www.apache.org/licenses/LICENSE-2.0
+%%
+%%    Unless required by applicable law or agreed to in writing, software
+%%    distributed under the License is distributed on an "AS IS" BASIS,
+%%    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%    See the License for the specific language governing permissions and
+%%    limitations under the License.
+
+%% As recommended by http://www.erlang.org/doc/apps/erts/time_compat.erl
+
+%% @ doc This module provides compatibility for the OTP 18.0 depracation of erlang:now/0
+-module(erlang_js_time).
+-compile(nowarn_deprecated_function).		%prevent error for erlang:now() deprecation in OTP 18
+-export([timestamp/0]).
+
+%% @spec timestamp() -> timestamp()
+%% @doc Returns {MegaSecs, Secs, MicroSecs}
+timestamp() ->
+    try
+	erlang:timestamp()
+    catch
+	error:undef ->
+	    erlang:now()
+    end.

--- a/src/js_benchmark.erl
+++ b/src/js_benchmark.erl
@@ -38,9 +38,9 @@ run() ->
 %% @private
 time_calls(Ctx, Count) ->
     io:format("Starting: ~p~n", [Count]),
-    Start = erlang:now(),
+    Start = erlang_js_time:timestamp(),
     do_calls(Ctx, Count),
-    timer:now_diff(erlang:now(), Start) / Count.
+    timer:now_diff(erlang_js_time:timestamp(), Start) / Count.
 
 %% @private
 do_calls(_Ctx, 0) ->


### PR DESCRIPTION
Make erlang_js work in OTP 18.

This fixes the OTP 18 deprecation warnings for erlang:now(), which are fatal due to warnings_as_errors in the erl_opts setting in rebar.config.

The erlang_js_timestamp.erl code is from http://www.erlang.org/doc/apps/erts/time_compat.erl

The modified erlang_js application passes "make test" in [basho/otp](https://github.com/basho/otp) branches [basho-otp16](https://github.com/basho/otp/tree/basho-otp-16), [basho-otp-17](https://github.com/basho/otp/tree/basho-otp-17), and [basho-otp-18](https://github.com/basho/otp/tree/basho-otp-18). "All 55 tests passed."
