### PR TITLE
Fix incorrect constant on return

### DIFF
--- a/c_src/spidermonkey.c
+++ b/c_src/spidermonkey.c
@@ -130,7 +130,7 @@ JSBool js_log(JSContext *cx, uintN argc, jsval *vp) {
       JS_SET_RVAL(cx, vp, JSVAL_FALSE);
     }
   }
-  return JSVAL_TRUE;
+  return JS_TRUE;
 }
 
 void sm_configure_locale(void) {


### PR DESCRIPTION
Looks like return value should be JS_TRUE rather than JSVAL_TRUE which is a different type. See:

https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/JSAPI_reference/JSVAL_TRUE
