### PR TITLE
Fix R18 erlang:now() deprecation warning

### DIFF
--- a/src/js_benchmark.erl
+++ b/src/js_benchmark.erl
@@ -38,9 +38,8 @@ run() ->
 %% @private
 time_calls(Ctx, Count) ->
     io:format("Starting: ~p~n", [Count]),
-    Start = erlang:now(),
-    do_calls(Ctx, Count),
-    timer:now_diff(erlang:now(), Start) / Count.
+    {Elapsed, _} = timer:tc(fun do_calls/2, [Ctx, Count]),
+    Elapsed / Count.
 
 %% @private
 do_calls(_Ctx, 0) ->


### PR DESCRIPTION
It solves #51 and #53 in simple backward compatible code.
