### PR TITLE
erl_exit was renamed to erts_exit since Erlang 18.3

### DIFF
--- a/c_src/driver_comm.c
+++ b/c_src/driver_comm.c
@@ -55,7 +55,7 @@ char *read_string(char **data) {
 void *ejs_alloc(ErlDrvSizeT size) {
     void *p = driver_alloc(size);
     if (p == NULL) {
-        erl_exit(1, "erlang_js: Can't allocate %lu bytes of memory\n", size);
+        erts_exit(1, "erlang_js: Can't allocate %lu bytes of memory\n", size);
     }
     return p;
 }

--- a/c_src/driver_comm.h
+++ b/c_src/driver_comm.h
@@ -30,7 +30,7 @@ char *read_string(char **data);
 
 /* Wrapper around driver_alloc() that checks  */
 /* for OOM.                                   */
-void erl_exit(int n, char*, ...);
+void erts_exit(int n, char*, ...);
 void *ejs_alloc(ErlDrvSizeT size);
 
 #endif


### PR DESCRIPTION
Please, do not merge it as is since it will breaks compiling on previous Erlang versions. I'd like to create this pull request to simplify other's efforts to build erlang_js with a very recent Erlang versions.

Signed-off-by: Peter Lemenkov lemenkov@gmail.com
