### PR TITLE
Update timestamp usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ notifications:
   webhooks: http://basho-engbot.herokuapp.com/travis?key=9b0dc343d8addd889d7a8d64c9b8b48dd22370aa
   email: eng@basho.com
 otp_release:
+  - 18.2.1
+  - 17.5
   - R15B01
   - R15B
   - R14B04

--- a/src/js_benchmark.erl
+++ b/src/js_benchmark.erl
@@ -38,9 +38,9 @@ run() ->
 %% @private
 time_calls(Ctx, Count) ->
     io:format("Starting: ~p~n", [Count]),
-    Start = erlang:now(),
+    Start = os:timestamp(),
     do_calls(Ctx, Count),
-    timer:now_diff(erlang:now(), Start) / Count.
+    timer:now_diff(os:timestamp(), Start) / Count.
 
 %% @private
 do_calls(_Ctx, 0) ->


### PR DESCRIPTION
I was testing out a few things with this library and noticed that it was failing to compile under Erlang/OTP 18+ because of the usage of `erlang:now()`. Not sure if this is the right move for the overall project, but if other people want to build this on more recent versions of erlang they might want to make a similar patch.

The [deprecation information is documented](http://erlang.org/doc/apps/erts/time_correction.html) in the erts docs for why they deprecated this.
