### PR TITLE
Fix compilation issues with OTP > 18.3

### DIFF
--- a/c_src/driver_comm.c
+++ b/c_src/driver_comm.c
@@ -55,7 +55,7 @@ char *read_string(char **data) {
 void *ejs_alloc(ErlDrvSizeT size) {
     void *p = driver_alloc(size);
     if (p == NULL) {
-        erl_exit(1, "erlang_js: Can't allocate %lu bytes of memory\n", size);
+        erts_exit(1, "erlang_js: Can't allocate %lu bytes of memory\n", size);
     }
     return p;
 }

--- a/c_src/driver_comm.h
+++ b/c_src/driver_comm.h
@@ -30,7 +30,7 @@ char *read_string(char **data);
 
 /* Wrapper around driver_alloc() that checks  */
 /* for OOM.                                   */
-void erl_exit(int n, char*, ...);
+void erts_exit(int n, char*, ...);
 void *ejs_alloc(ErlDrvSizeT size);
 
 #endif


### PR DESCRIPTION
I'm not familiar enough with C preprocessor voodoo to figure out how to make the switch from erl_exit to erts_exit backwards compatible, so if anyone has any tips that would be great (having said that, OTP itself wasn't backwards compatible).

I actually think this project should just use it's own exit functions instead of relying on those in OTP because they're not actually meant to be public: https://github.com/erlang/otp/blob/9c013e2f9f7e32de38dc9640038aee1840d68e04/erts/emulator/drivers/common/inet_drv.c#L1398. It was changed without PR and broken in a minor version.

This is a retarget of #58.
