### PR TITLE
Only build `libjs.a`

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -33,7 +33,7 @@ $(LIB_DIR)/libjs.a: $(LIB_DIR)/libnspr4.a
 		JS_THREADSAFE=1 \
 		XCFLAGS="-DHAVE_VA_COPY -DVA_COPY=va_copy $(CFLAGS)" \
 		XLDFLAGS="$(LDFLAGS)" \
-		-f Makefile.ref
+		-f Makefile.ref libjs.a
 	@mkdir $(INC_DIR)/js
 	@cp $(JS_DIR)/src/*.h $(INC_DIR)/js
 	@cp $(JS_DIR)/src/*.tbl $(INC_DIR)/js


### PR DESCRIPTION
The original makefile build `libjs.a` along with the `js` CLI tool which isn't needed. This change should fix the issue at #1669