### PR TITLE
Spelling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # This is a stub Makefile that invokes GNU make which will read the GNUmakefile
-# instead of this file. This provides compatability on systems where GNU make is
+# instead of this file. This provides compatibility on systems where GNU make is
 # not the system 'make' (eg. most non-linux UNIXes).
 
 all:

--- a/src/js.erl
+++ b/src/js.erl
@@ -18,7 +18,7 @@
 %% args into JSON before sending them to Javascript. While this does
 %% incur a certain amount of overhead it has the benefit of (mostly)
 %% preserving types as they roundtrip between Erlang and Javascript.
-%% Of course, this also means all Erlang values MUST BE convertable
+%% Of course, this also means all Erlang values MUST BE convertible
 %% into JSON. In practice, this is less restricting than it sounds.
 -module(js).
 

--- a/src/js_driver.erl
+++ b/src/js_driver.erl
@@ -14,8 +14,8 @@
 %%    limitations under the License.
 
 %% @doc This module manages all of the low-level details surrounding the
-%% linked-in driver. It is reponsible for loading and unloading the driver
-%% as needed. This module is also reponsible for creating and destroying
+%% linked-in driver. It is responsible for loading and unloading the driver
+%% as needed. This module is also responsible for creating and destroying
 %% instances of Javascript VMs.
 
 -module(js_driver).


### PR DESCRIPTION
Generated by https://github.com/jsoref/spelling `f`; to maintain your repo, please consider `fchurn`