### PR TITLE
Fix some issues linking erlang_js on recent FreeBSD (12.2).

### DIFF
--- a/c_src/patches/js-src-config-FreeBSD.mk.patch
+++ b/c_src/patches/js-src-config-FreeBSD.mk.patch
@@ -50,7 +50,7 @@
 +OS_CFLAGS = -DXP_UNIX -DSVR4 -DSYSV -D_BSD_SOURCE -DPOSIX_SOURCE -DHAVE_LOCALTIME_R
 +
 +RANLIB = echo
-+MKSHLIB = $(LD) -shared $(XMKSHLIBOPTS)
++MKSHLIB = $(CC) -shared $(XMKSHLIBOPTS)
 +
 +#.c.o:
 +#      $(CC) -c -MD $*.d $(CFLAGS) $<

--- a/rebar.config
+++ b/rebar.config
@@ -36,7 +36,10 @@
 
              %% Prevent the make->gmake transition from infecting
              %% MAKEFLAGS with bad flags that confuse gmake
-             {"freebsd.*", "MAKEFLAGS", ""}
+             {"freebsd.*", "MAKEFLAGS", ""},
+
+             %% Missing -lreadline
+             {"freebsd.*", "LDFLAGS", "-L/usr/local/lib"}
 
             ]}.
 


### PR DESCRIPTION
There are two issues:

o linker (LD) has no such option -lm. CC should be used instead like on all other arches;

o libreadline is now living in the /usr/local/lib.

This can be merged into develop-2.9 as well. Thanks!